### PR TITLE
Added kad-logger-json package

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "jsen": "^0.6.6",
     "json-stable-stringify": "^1.0.1",
     "kad": "^1.6.4",
+    "kad-logger-json": "^0.1.2",
     "kad-quasar": "^1.2.4",
     "kfs": "github:StorXNetwork/kfs",
     "knuth-shuffle": "^1.0.1",


### PR DESCRIPTION
Reason :
-- kad-logger-json package was used in lib/storage/manager.js file but was not added in package.json


Explanation: 
-- Since, the package was used on source code. Running the repo used to crash because of import issues of the missing package in package.json. Adding that in package.json fixed the issue

